### PR TITLE
Added config option for letting only certain ranks within a faction spawn fmobs.

### DIFF
--- a/src/com/gmail/scyntrus/fmob/FactionMobs.java
+++ b/src/com/gmail/scyntrus/fmob/FactionMobs.java
@@ -142,7 +142,7 @@ public class FactionMobs extends JavaPlugin {
 		FactionMobs.feedEnabled = config.getBoolean("feedEnabled", FactionMobs.feedEnabled);
 		FactionMobs.feedAmount = (float) config.getDouble("feedAmount", FactionMobs.feedAmount);
 		FactionMobs.mustBeAtleast = config.getString("mustBeAtleast", FactionMobs.mustBeAtleast);
-		if(mustBeAtleast.equalsIgnoreCase("mod") mustBeAtleast = "Moderator";
+		if(mustBeAtleast.equalsIgnoreCase("mod")) mustBeAtleast = "Moderator";
 		
 		Archer.maxHp = (float) config.getDouble("Archer.maxHp", Archer.maxHp);
 		if (Archer.maxHp<1) Archer.maxHp = 1;

--- a/src/com/gmail/scyntrus/fmob/FactionMobs.java
+++ b/src/com/gmail/scyntrus/fmob/FactionMobs.java
@@ -59,6 +59,7 @@ public class FactionMobs extends JavaPlugin {
 	public static boolean feedEnabled = true;
 	public static float feedAmount = 5;
 	public static boolean silentErrors = true;
+	public static String mustBeAtleast = "MEMBER";
 	
 	@SuppressWarnings("unchecked")
 	public void onEnable() {
@@ -140,6 +141,7 @@ public class FactionMobs extends JavaPlugin {
 		FactionMobs.mobNavRange = (float) config.getDouble("mobNavRange", FactionMobs.mobNavRange);
 		FactionMobs.feedEnabled = config.getBoolean("feedEnabled", FactionMobs.feedEnabled);
 		FactionMobs.feedAmount = (float) config.getDouble("feedAmount", FactionMobs.feedAmount);
+		FactionMobs.mustBeAtleast = config.getString("mustBeAtleast", FactionMobs.mustBeAtleast);
 		
 		Archer.maxHp = (float) config.getDouble("Archer.maxHp", Archer.maxHp);
 		if (Archer.maxHp<1) Archer.maxHp = 1;

--- a/src/com/gmail/scyntrus/fmob/FactionMobs.java
+++ b/src/com/gmail/scyntrus/fmob/FactionMobs.java
@@ -142,6 +142,7 @@ public class FactionMobs extends JavaPlugin {
 		FactionMobs.feedEnabled = config.getBoolean("feedEnabled", FactionMobs.feedEnabled);
 		FactionMobs.feedAmount = (float) config.getDouble("feedAmount", FactionMobs.feedAmount);
 		FactionMobs.mustBeAtleast = config.getString("mustBeAtleast", FactionMobs.mustBeAtleast);
+		if(mustBeAtleast.equalsIgnoreCase("mod") mustBeAtleast = "Moderator";
 		
 		Archer.maxHp = (float) config.getDouble("Archer.maxHp", Archer.maxHp);
 		if (Archer.maxHp<1) Archer.maxHp = 1;

--- a/src/com/gmail/scyntrus/fmob/FmCommand.java
+++ b/src/com/gmail/scyntrus/fmob/FmCommand.java
@@ -129,9 +129,11 @@ public class FmCommand implements CommandExecutor {
 						!player.hasPermission("fmob.spawn.mage") &&
 						!player.hasPermission("fmob.spawn.swordsman") &&
 						!player.hasPermission("fmob.spawn.titan")) {
+				if(UPlayer.getPlayerFaction(player) != null && !Utils.hasSpawnPermission(player)) {
 					player.sendMessage(ChatColor.RED + "You do not have permission.");
 					return true;
-				}
+				}							
+
 				Location loc = player.getLocation();
 				Faction playerfaction = UPlayer.getPlayerFaction(player);
 				if (playerfaction == null || playerfaction.isNone()) {

--- a/src/com/gmail/scyntrus/fmob/FmCommand.java
+++ b/src/com/gmail/scyntrus/fmob/FmCommand.java
@@ -124,15 +124,14 @@ public class FmCommand implements CommandExecutor {
 				player.sendMessage("You have not selected any mob");
 				return true;
 			} else if (split[0].equalsIgnoreCase("spawn")) {
-				if (!player.hasPermission("fmob.spawn") &&
+				if ((!player.hasPermission("fmob.spawn") &&
 						!player.hasPermission("fmob.spawn.archer") &&
 						!player.hasPermission("fmob.spawn.mage") &&
 						!player.hasPermission("fmob.spawn.swordsman") &&
-						!player.hasPermission("fmob.spawn.titan")) {
-				if(UPlayer.getPlayerFaction(player) != null && !Utils.hasSpawnPermission(player)) {
+						!player.hasPermission("fmob.spawn.titan") || (UPlayer.getPlayerFaction(player) != null && !Utils.hasSpawnPermission(player)))) {
 					player.sendMessage(ChatColor.RED + "You do not have permission.");
 					return true;
-				}							
+					}					
 
 				Location loc = player.getLocation();
 				Faction playerfaction = UPlayer.getPlayerFaction(player);

--- a/src/com/gmail/scyntrus/fmob/Utils.java
+++ b/src/com/gmail/scyntrus/fmob/Utils.java
@@ -142,6 +142,34 @@ public class Utils {
 		return count;
 	}
 	
+	public static boolean hasSpawnPermission(Player player) {
+		int i = Factions.factionsVersion;
+		switch (i) {
+		case 6:
+                        com.massivecraft.factions.FPlayer fp= null;
+	        	try {
+				fp = (com.massivecraft.factions.FPlayer)Factions.fPlayerGet.invoke(com.massivecraft.factions.FPlayers.i, player);
+			} catch (IllegalAccessException | IllegalArgumentException
+					| InvocationTargetException e) {
+				e.printStackTrace();
+			}
+               		com.massivecraft.factions.struct.Role role6 = fp.getRole();
+               		return role6.toString().equalsIgnoreCase(FactionMobs.mustBeAtleast);
+		case 8:
+			final com.massivecraft.factions.struct.Role r = com.massivecraft.factions.FPlayers.i.get(player).getRole();
+        	        return r.toString().equalsIgnoreCase(FactionMobs.mustBeAtleast);
+		case 2:
+		com.massivecraft.factions.Rel r1 = com.massivecraft.factions.entity.MPlayer.get(player).getRole();
+			String role = "";
+			if(r1 == com.massivecraft.factions.Rel.MEMBER) role = "NORMAL";
+			if(r1 == com.massivecraft.factions.Rel.OFFICER) role = "MODERATOR";
+			if(r1 == com.massivecraft.factions.Rel.LEADER) role = "ADMIN";
+            	return role.equalsIgnoreCase(FactionMobs.mustBeAtleast);
+                       	}
+		return false;
+
+	}	
+	
 	public static void copyDefaultConfig() {
 		InputStream stream = Utils.class.getResourceAsStream("/config.yml");
 		if (stream == null) {

--- a/src/com/gmail/scyntrus/fmob/Utils.java
+++ b/src/com/gmail/scyntrus/fmob/Utils.java
@@ -21,6 +21,7 @@ import org.bukkit.entity.Player;
 
 import com.gmail.scyntrus.ifactions.Faction;
 import com.gmail.scyntrus.ifactions.UPlayer;
+import com.gmail.scyntrus.ifactions.Factions;
 
 public class Utils {
 	public static int FactionCheck(EntityLiving entity, Faction faction) {

--- a/src/config.yml
+++ b/src/config.yml
@@ -20,7 +20,7 @@ noFriendlyFire: true
 # Players cannot damage mobs on allied teams regardless
 noPlayerFriendlyFire: true
 
-# Rank required in order to spawn faction mobs, Member, Officer (Moderator) and Leader (Admin/Owner).
+# Rank required in order to spawn faction mobs, you can choose from 'Member', 'Moderator' (Officer) and 'Admin' (Leader).
 mustBeAtleast: MEMBER
 
 # Attacking a faction member or faction mob will agro their nearby faction mobs

--- a/src/config.yml
+++ b/src/config.yml
@@ -20,6 +20,9 @@ noFriendlyFire: true
 # Players cannot damage mobs on allied teams regardless
 noPlayerFriendlyFire: true
 
+# Rank required in order to spawn faction mobs, Member, Officer (Moderator) and Leader (Admin/Owner).
+mustBeAtleast: MEMBER
+
 # Attacking a faction member or faction mob will agro their nearby faction mobs
 alertAllies: true
 


### PR DESCRIPTION
This PR makes it possible to let only certain ranks within a faction spawn faction mobs, like moderators. This is done by changing in the mustBeAtleast option in the config. I've added support for each version of factions and tested it with factions 1.6 and it worked.
